### PR TITLE
Parham/palette project tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ bin/
 obj/
 dotnet-backend/APIs/appsettings.json
 
+dotnet-backend/Infrastructure/Migrations
 
 *.xlsx

--- a/dotnet-backend/APIs/Controllers/PaletteController.cs
+++ b/dotnet-backend/APIs/Controllers/PaletteController.cs
@@ -26,6 +26,25 @@ namespace APIs.Controllers
         })
         .WithName("UploadAssets")
         .WithOpenApi();
+        
+        // update the images in the palette with the selected project tags
+        app.MapPatch("/palette/images/tags", async (AssignTagsToPaletteReq request, IPaletteService paletteService, ILogger<Program> logger) => 
+        {
+            var result = await paletteService.AddTagsToPaletteImagesAsync(request.ImageIds, request.ProjectId);
+            if (result) {
+                return Results.Ok(new {
+                    status = "success",
+                    projectId = request.ProjectId,
+                    updatedImages = request.ImageIds,
+                    message = "Tags successfully added to selected images in the palette."
+                });
+            } else {
+                Console.WriteLine($"Failed to assign project tags to images for ProjectId {result}.");
+                return Results.NotFound("Failed to assign project tags to images");
+            }
+        })
+        .WithName("ModifyTags")
+        .WithOpenApi();
 
 
         //     // tag assets in the palette
@@ -36,9 +55,6 @@ namespace APIs.Controllers
            
         //    // upload assets permanently
         //     app.MapPost("/projects/upload-assets", UploadAssets).WithName("UploadAssets").WithOpenApi();
-
-        //     // delete/add tags
-        //     app.MapPatch("/palette/assets/{assetId}/tags", ModifyTags).WithName("ModifyTags").WithOpenApi();
 
         }
 

--- a/dotnet-backend/Core/Dtos/AssignTagsToPaletteReq.cs
+++ b/dotnet-backend/Core/Dtos/AssignTagsToPaletteReq.cs
@@ -1,0 +1,5 @@
+public class AssignTagsToPaletteReq
+{
+    public List<int> ImageIds { get; set; } = new List<int>();
+    public int ProjectId { get; set; }
+}

--- a/dotnet-backend/Core/Entities/DataModel.cs
+++ b/dotnet-backend/Core/Entities/DataModel.cs
@@ -48,6 +48,7 @@ namespace Core.Entities
         public virtual User? User { get; set; }
         
         public virtual ICollection<AssetMetadata> AssetMetadata { get; set; } = new List<AssetMetadata>();
+        public virtual ICollection<AssetTag> AssetTags { get; set; } = new List<AssetTag>();
     }
 
     public class Project
@@ -71,6 +72,8 @@ namespace Core.Entities
         public virtual ICollection<Asset> Assets { get; set; } = new List<Asset>();
         public virtual ICollection<ProjectMembership> ProjectMemberships { get; set; } = new List<ProjectMembership>();
         public virtual ICollection<ProjectMetadataField> ProjectMetadataFields { get; set; } = new List<ProjectMetadataField>();
+
+        public virtual ICollection<ProjectTag> ProjectTags { get; set; } = new List<ProjectTag>();
         
         // Each project can have one Palette ??
         public virtual Palette Palette { get; set; }
@@ -172,6 +175,37 @@ namespace Core.Entities
         public required virtual MetadataField MetadataField { get; set; }
     }
 
+    public class ProjectTag 
+    {
+        [Key]
+        public int ProjectID { get; set; }
+        [Key]
+        public int TagID { get; set; }
+
+
+        [ForeignKey("ProjectID")]
+        public required virtual Project Project { get; set; }
+
+        [ForeignKey("TagID")]
+        public required virtual Tag Tag { get; set; }
+
+    }
+
+    public class AssetTag
+    {
+        [Key]
+        public int BlobID { get; set; }
+        [Key]
+        public int TagID { get; set; }
+        
+        [ForeignKey("BlobID")]
+        public required virtual Asset Asset { get; set; }
+
+        [ForeignKey("TagID")]
+        public required virtual Tag Tag { get; set; }
+
+    }
+
     // Optional: A simple Tag table.
     public class Tag
     {
@@ -179,6 +213,9 @@ namespace Core.Entities
         public int TagID { get; set; }
         
         public required string Name { get; set; }
+
+        public virtual ICollection<ProjectTag> ProjectTags { get; set; } = new List<ProjectTag>();
+        public virtual ICollection<AssetTag> AssetTags { get; set; } = new List<AssetTag>();
     }
 
 }

--- a/dotnet-backend/Core/Interfaces/IPaletteRepository.cs
+++ b/dotnet-backend/Core/Interfaces/IPaletteRepository.cs
@@ -6,7 +6,12 @@ namespace Core.Interfaces  {
     public interface IPaletteRepository {
         public Task<List<Asset>> GetAssetsFromPalette();
 
+        public Task<List<string>> GetProjectTagsAsync(int projectId);
+
+        public Task<bool> AddTagsToPaletteImagesAsync(List<int> imageIds, List<string> tags);
+
         public Task<bool> UploadAssets(IFormFile file, UploadAssetsReq request);
+
 
     }
 }

--- a/dotnet-backend/Core/Interfaces/IPaletteService.cs
+++ b/dotnet-backend/Core/Interfaces/IPaletteService.cs
@@ -10,5 +10,8 @@ namespace Core.Interfaces
     {
         Task<bool> ProcessUploadAsync(IFormFile file, UploadAssetsReq request);
         Task<bool[]> ProcessUploadsAsync(IList<IFormFile> files, UploadAssetsReq request);
+        Task<List<string>> GetProjectTagsAsync(int projectId);
+        Task<bool> AddTagsToPaletteImagesAsync(List<int> imageIds, int projectId);
+
     }
 }

--- a/dotnet-backend/Core/Services/PaletteService.cs
+++ b/dotnet-backend/Core/Services/PaletteService.cs
@@ -24,6 +24,17 @@ namespace Core.Services
                 return false;
             }
         }
+
+        public async Task<List<string>> GetProjectTagsAsync(int projectId) {
+            return await _paletteRepository.GetProjectTagsAsync(projectId);
+        }
+
+        public async Task<bool> AddTagsToPaletteImagesAsync(List<int> imageIds, int projectId) {
+            var projectTags = await _paletteRepository.GetProjectTagsAsync(projectId);
+            if (!projectTags.Any()) return false;
+            return await _paletteRepository.AddTagsToPaletteImagesAsync(imageIds, projectTags);
+        }
+        
         
         public async Task<bool[]> ProcessUploadsAsync(IList<IFormFile> files, UploadAssetsReq request)
         {

--- a/dotnet-backend/Infrastructure/DataAccess/DbContext.cs
+++ b/dotnet-backend/Infrastructure/DataAccess/DbContext.cs
@@ -17,6 +17,8 @@ namespace Infrastructure.DataAccess {
         public DbSet<ProjectMetadataField> ProjectMetadataFields { get; set; }
         public DbSet<AssetMetadata> AssetMetadata { get; set; }
         public DbSet<Tag> Tags { get; set; }
+        public DbSet<ProjectTag> ProjectTags { get; set; }
+        public DbSet<AssetTag> AssetTags { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -29,6 +31,12 @@ namespace Infrastructure.DataAccess {
 
             modelBuilder.Entity<AssetMetadata>()
                 .HasKey(am => new { am.BlobID, am.FieldID });
+            
+            modelBuilder.Entity<ProjectTag>()
+                .HasKey(pt => new { pt.ProjectID, pt.TagID });
+
+            modelBuilder.Entity<AssetTag>()
+                .HasKey(at => new { at.BlobID, at.TagID });
 
             base.OnModelCreating(modelBuilder);
         }

--- a/dotnet-backend/Infrastructure/DataAccess/PaletteRepository.cs
+++ b/dotnet-backend/Infrastructure/DataAccess/PaletteRepository.cs
@@ -12,7 +12,6 @@ namespace Infrastructure.DataAccess {
 
         private readonly IDbContextFactory<DAMDbContext> _contextFactory;
         private readonly bool _useZstd;
-        private readonly IProjectService _projectService;
 
         public PaletteRepository(IDbContextFactory<DAMDbContext> contextFactory) 
         {


### PR DESCRIPTION
This PR covers adding the following endpoint and functionality for the palette

1. Added PATCH /palette/image/tags endpoint which update the images in the palette with the selected project tags. This endpoint should be called for when a project is selected, and will update a list of assets/images who are going to be associate with this project with the project tags.

Note that deleting these tags is not implemented yet.

2. Updated the dataModel:
- We now have AssetTag and ProjectTag Tables.
- The relationship is now formed as: A project has ProjectTags, and a Asset has AssetTags, and these tags contain Tag information.

3. also added migrations to the .gitignore.